### PR TITLE
Updated implicit casting to prevent compilation errors.

### DIFF
--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -143,11 +143,11 @@ export class Normalizer
         const distinctProps = this.distinctProps(firstRow);
         const distinctTypes = this.distinctTypes(firstRow);
 
-        let metadata = {};
-        let bitDataset = [];
+        let metadata: any = {};
+        let bitDataset: any = [];
 
         for (let prop of distinctProps) {
-            const type = distinctTypes[prop];
+          const type: string = (<any>distinctTypes)[prop];
 
             metadata[prop] = {
                 type: type,
@@ -259,7 +259,7 @@ export class Normalizer
      */
     strToBitsArr(distinctValues: any, val: string)
     {
-        let bitArr = new Array(distinctValues.length);
+        let bitArr: any = new Array(distinctValues.length);
         bitArr.fill(0);
 
         for (let i in distinctValues) {
@@ -292,7 +292,7 @@ export class Normalizer
 
     distinctTypes(row: RowInput)
     {
-        let distinctTypes = {};
+        let distinctTypes: any = {};
 
         for (let prop in row) {
             const value = row[prop];


### PR DESCRIPTION
## Issue ##

Compilation fails when a project doesn't allow implicit type casting using the following setting `noImplicitAny: true` as a measure to prevent code errors.

Errors thrown during compilation are as follows:

```
node_modules/neural-data-normalizer/src/normalizer.ts(152,13): error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
node_modules/neural-data-normalizer/src/normalizer.ts(163,21): error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
node_modules/neural-data-normalizer/src/normalizer.ts(164,21): error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
node_modules/neural-data-normalizer/src/normalizer.ts(168,21): error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
node_modules/neural-data-normalizer/src/normalizer.ts(169,21): error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
node_modules/neural-data-normalizer/src/normalizer.ts(175,21): error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
node_modules/neural-data-normalizer/src/normalizer.ts(179,21): error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
node_modules/neural-data-normalizer/src/normalizer.ts(267,24): error TS7015: Element implicitly has an 'any' type because index expression is not of type 'number'.
node_modules/neural-data-normalizer/src/normalizer.ts(302,17): error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
node_modules/neural-data-normalizer/src/normalizer.ts(304,17): error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
node_modules/neural-data-normalizer/src/normalizer.ts(306,17): error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
```

## What's changed ##

Removed all instances of implicit type casting with a simple `any` declaration for variables that were missing a type declaration.